### PR TITLE
Switch from teams to collaborators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Hello World Action
+# GitHub Repository Auditing Action
 
-> A simple GitHub Action written in JavaScript
+> An action to audit all repository collaborators and their permissions
 
 [![Build Status](https://github.com/gr2m/github-organization-repository-auditing-action/actions/workflows/test.yml/badge.svg)](https://github.com/gr2m/github-organization-repository-auditing-action/actions/workflows/test.yml)
 
@@ -94,7 +94,7 @@ jobs:
 
 ## How it works
 
-This action is using the GitHub App SDK from [`octokit`](https://github.com/octokit/octokit.js/#app-client). It iterates through all repositories the app is installed an, loads all teams with their permissions, and writes a resulting `repositories` array to the GitHub Action step output using [`@actions/core`](https://github.com/actions/toolkit/tree/main/packages/core).
+This action is using the GitHub App SDK from [`octokit`](https://github.com/octokit/octokit.js/#app-client). It iterates through all repositories the app is installed an, loads all collaborators with their permissions, and writes a resulting `repositories` array to the GitHub Action step output using [`@actions/core`](https://github.com/actions/toolkit/tree/main/packages/core).
 
 The entire code is in [`index.js`](index.js)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -16503,19 +16503,20 @@ async function run() {
 
   const repositories = [];
   for await (const { octokit, repository } of app.eachRepository.iterator()) {
-    core.info(`Auditing ${repository.full_name}`);
+    core.startGroup(`Auditing ${repository.full_name}`);
 
-    const teams = await octokit.paginate(octokit.rest.repos.listTeams, {
+    const collaborators = await octokit.paginate(octokit.rest.repos.listCollaborators, {
       owner: repository.owner.login,
       repo: repository.name,
       per_page: 100,
     });
 
-    for (const team of teams) {
-      core.info(`- ${team.name}: ${normalizePermission(team.permissions)}`);
+    for (const collaborator of collaborators) {
+      core.info(`- ${collaborator.login}: ${normalizePermission(collaborator.permissions)}`);
     }
-
-    repositories.push(toLogItem(repository, teams));
+    
+    repositories.push(toLogItem(repository, collaborators));
+    core.endGroup();
   }
 
   core.setOutput("repositories", JSON.stringify(repositories));
@@ -16542,18 +16543,16 @@ function normalizePermission(permissions) {
  * @param {import("@octokit/openapi-types").components["schemas"]["repository"]} repository
  * @param {import("@octokit/openapi-types").components["schemas"]["team"][]} teams
  */
-function toLogItem(repository, teams) {
+function toLogItem(repository, collaborators) {
   return {
     id: repository.id,
     name: repository.name,
-    teams: teams.map((team) => {
+    collaborators: collaborators.map((collaborator) => {
       return {
-        id: team.id,
-        slug: team.slug,
-        name: team.name,
+        login: collaborator.login,
         // team.permissions is currently missing in types,
         // see https://github.com/github/rest-api-description/issues/289
-        permission: normalizePermission(team.permissions),
+        permission: normalizePermission(collaborator.permissions),
       };
     }),
   };


### PR DESCRIPTION
### TL;DR

This PR modifies the action to audit a repository's collaborators instead of its teams.

### Why?

1. Many organizations require a static list of permissions for auditing. The present use of `teams` doesn't meet this need as:

* a separate lookup is required to determine which people are on which team
* team membership is dynamic, which would require organizations to also capture the membership of each team at the time of each action run

2. Outside collaborators and individual organization members added to the repository are not captured when auditing repository teams. 

3. the `listCollaborators` endpoint returns all collaborators, whether added as a member of an organization team, member of the org, or an outside collaborator

### What this PR does

* Modifies the action logic to get collaborators instead of teams
* Groups log output by repository using `core.startGroup()` and `core.endGroup()`
* Updates the README

The resulting JSON object is much longer, but provides a complete audit of all users with access to repos as well as their access levels.